### PR TITLE
added 50fps

### DIFF
--- a/reflex_curses/gnitch.py
+++ b/reflex_curses/gnitch.py
@@ -558,9 +558,9 @@ class Keybinds:
                 player = config.cp["exec"]["player"].replace("'", '"')
                 quality = ui.quality[ui.cur_quality]
 
-                # prefer 60fps streams, but fallback if they aren't available
+                # prefer 60fps/50fps streams, but fallback if they aren't available
                 if quality[-1] == 'p':
-                    quality = f"{quality}60,{quality}"
+                    quality = f"{quality}60,{quality}50,{quality}"
 
                 cmd = (
                     f"setsid "  # detach process from terminal


### PR DESCRIPTION
On rare occasions streams are available in 50fps instead of 60.
Potentially needs to be pulled from variable, in case other more exotic options are available.